### PR TITLE
Fix TypeScript type imports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,11 +10,11 @@
  * @typedef {import('mdast-util-from-markdown').OnEnterError} OnEnterError
  * @typedef {import('mdast-util-from-markdown').OnExitError} OnExitError
  * @typedef {import('estree-jsx').Program} Program
- * @typedef {import('./complex-types').MdxJsxAttributeValueExpression} MdxJsxAttributeValueExpression
- * @typedef {import('./complex-types').MdxJsxAttribute} MdxJsxAttribute
- * @typedef {import('./complex-types').MdxJsxExpressionAttribute} MdxJsxExpressionAttribute
- * @typedef {import('./complex-types').MdxJsxFlowElement} MdxJsxFlowElement
- * @typedef {import('./complex-types').MdxJsxTextElement} MdxJsxTextElement
+ * @typedef {import('./complex-types.js').MdxJsxAttributeValueExpression} MdxJsxAttributeValueExpression
+ * @typedef {import('./complex-types.js').MdxJsxAttribute} MdxJsxAttribute
+ * @typedef {import('./complex-types.js').MdxJsxExpressionAttribute} MdxJsxExpressionAttribute
+ * @typedef {import('./complex-types.js').MdxJsxFlowElement} MdxJsxFlowElement
+ * @typedef {import('./complex-types.js').MdxJsxTextElement} MdxJsxTextElement
  * @typedef {{name: string|null, attributes: (MdxJsxAttribute|MdxJsxExpressionAttribute)[], close?: boolean, selfClosing?: boolean, start: Token['start'], end: Token['start']}} Tag
  *
  * @typedef ToMarkdownOptions

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "lib": ["ES2020"],
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript 4.7 includes the new `node16` module resolution value. This requires imports to have an extension, even if the import doesn’t reference an existing `.js` file.

This still works with other module resolution values.

<!--do not edit: pr-->
