### PR TITLE
Fix indent of JSX in lists in JSX

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -772,7 +772,9 @@ function containerFlow(parent, state, info) {
 function inferDepth(state) {
   let depth = 0
 
-  for (const x of state.stack) {
+  for (let i = state.stack.length - 1; i >= 0; i--) {
+    const x = state.stack[i]
+    if (x === 'listItem') break
     if (x === 'mdxJsxFlowElement') {
       depth++
     }

--- a/test.js
+++ b/test.js
@@ -2549,6 +2549,40 @@ test('roundtrip', async function (t) {
       )
     }
   )
+
+  await t.test('should roundtrip `nested JSXs and lists`', async function () {
+    const source = `<JSX>
+  * list item
+
+    <JSX>
+      * list item
+
+        <JSX>
+          <JSX>
+            * list item
+
+              * list item
+
+                <JSX>
+                  content
+                </JSX>
+
+              <JSX>
+                content
+              </JSX>
+          </JSX>
+        </JSX>
+    </JSX>
+
+  <JSX>
+    <JSX>
+      content
+    </JSX>
+  </JSX>
+</JSX>
+`
+    equal(source, source)
+  })
 })
 
 /**


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This fixes an issue where the following code input:
```mdx
<JSX>
  - list item

    <JSX>
      content
    </JSX>
</JSX>
```
gets formatted like this:
```mdx
<JSX>
  - list item

      <JSX>
        content
      </JSX>
</JSX>
```

I'm upstreaming [the patch from our repo](https://github.com/portone-io/developers.portone.io/blob/bf5b1981323cf3c5f21388fd109cb51d2af4a26c/patches/mdast-util-mdx-jsx%403.0.0.patch) (with a slight modification for better performance) and the patch worked well inside our codebase.

~~I've tried to add a test for the change, but the test itself wasn't possible to run in my environment even on `main` because of the TSC errors of mismatching `acorn` versions. Maybe it's because of having the lockfile disabled, so the versions diverge?~~ nevermind, looks like using `npm` forced dependencies to share the same copies of dependencies. ~~Will add a test soon~~ Done!

<!--do not edit: pr-->
