### PR TITLE
Test case for multiline string attribute values

### DIFF
--- a/test.js
+++ b/test.js
@@ -2622,6 +2622,26 @@ test('roundtrip', async function (t) {
       equal(source, source)
     }
   )
+
+  await t.test(
+    'should roundtrip `JSX attributes containing new lines`',
+    async function () {
+      equal(
+        `<a\n  text={\`\n0\n 1\n  2\n   3\n    4\n     5\`}\n/>\n`,
+        `<a\n  text={\`\n0\n 1\n  2\n   3\n    4\n     5\`}\n/>\n`
+      )
+    }
+  )
+
+  await t.test(
+    'should roundtrip `JSX multiline string children`',
+    async function () {
+      equal(
+        `<a\n  trigger={<b>{\`\n0\n 1\n  2\n   3\n    4\n     5\`}</b>}\n/>\n`,
+        `<a\n  trigger={<b>{\`\n0\n 1\n  2\n   3\n    4\n     5\`}</b>}\n/>\n`
+      )
+    }
+  )
 })
 
 /**


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope,
  provide a general description of the changes, and remember, it’s up to you to
  convince us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
* [x] If applicable, I’ve added docs and tests

### Description of changes

The initial 2 spaces are always trimmed from multiline string values in JSX attributes. I encountered this when trying to render code in MDX by doing something like this:

```tsx
JSON example:

<JsonCodeBlock code={`
{
  foo: "bar"
}`} />

Rest of the page here…
```

What ends up happening is that the string is parsed as `\n{\nfoo: "bar"\n}` and the indentation is lost.

Examples in the wild:

- https://docusaurus.io/docs/markdown-features/code-blocks#usage-in-jsx (the rendered code block is incorrectly indented)
- https://www.nativewind.dev/tailwind/new-concepts/safe-area-insets#compatibility

This PR adds a test case for it, but I'm not sure the best approach to fixing this.

<!--do not edit: pr-->
